### PR TITLE
Made `/linkoss` better.

### DIFF
--- a/cogs/SlashCommands.py
+++ b/cogs/SlashCommands.py
@@ -10,23 +10,18 @@ class SlashCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    times_slash_linkoss_used = 0
-
     @commands.slash_command(
         name = 'linkoss',
         description = 'Remind Linkoss to drink tea!'
     )
+    @commands.cooldown(10, 30, commands.BucketType.channel)
     async def tea(self, ctx: ApplicationCommandInteraction):
-        global times_slash_linkoss_used
-        if times_slash_linkoss_used <= 9:
-            global times_slash_linkoss_used
-            times_slash_linkoss_used += 1
-            await ctx.response.send_message('<@359812392504524811> Reminder to drink tea')
-        else:
-            await ctx.response.send_message('Linkoss has had enough tea already :slight_smile:')
-            await asyncio.sleep(20)
-            global times_slash_linkoss_used
-            times_slash_linkoss_used = 0
+        await ctx.response.send_message('<@359812392504524811> Reminder to drink tea')
+    
+    @tea.error
+    async def nomentionlinkoss(self, ctx, error):
+        if isinstance(error, commands.CommandOnCooldown):
+            await ctx.response.send_message(f'Linkoss can drink tea again after {error.retry_after}s. :slight_smile:')
 
     @commands.slash_command(
         name = 'ping',

--- a/cogs/SlashCommands.py
+++ b/cogs/SlashCommands.py
@@ -3,8 +3,6 @@ from disnake.ext import commands
 from disnake.utils import get
 from disnake import ApplicationCommandInteraction, Option, OptionType, OptionChoice
 
-import asyncio
-
 class SlashCog(commands.Cog):
     
     def __init__(self, bot):

--- a/cogs/WeeklyRoles.py
+++ b/cogs/WeeklyRoles.py
@@ -1,0 +1,66 @@
+import disnake
+from disnake import utils, MessageInteraction
+from disnake.ext import commands
+
+class RoleButtons(disnake.ui.View):
+
+    def __init__(self):
+        super().__init__(timeout = None)
+    
+    @disnake.ui.button(
+        label = 'cevala feko', 
+        style = disnake.ButtonStyle.grey,
+        custom_id = 'wrone'
+    )
+    async def wrone(self, button: disnake.ui.Button, ctx: MessageInteraction):
+
+        wrone = utils.get(ctx.guild.roles, name = 'cevala feko')
+        wrtwo = utils.get(ctx.guild.roles, name = '1969 paris wind')
+        prison = utils.get(ctx.guild.roles, name = 'prisoner')
+
+        if wrone in ctx.author.roles:
+            return await ctx.response.send_message('You already have it lol.', ephemeral = True)
+        elif (wrone not in ctx.author.roles) and (wrtwo in ctx.author.roles):
+            await ctx.author.add_roles(prison)
+            await ctx.author.remove_roles(wrtwo)
+            await ctx.response.send_message('Be imprisoned.', ephemeral = True)
+            return    
+        await ctx.author.add_roles(wrone)
+        await ctx.response.send_message('You got it mate, congrats.', ephemeral = True)
+    
+    @disnake.ui.button(
+        label = '1969 paris wind',
+        style = disnake.ButtonStyle.grey,
+        custom_id = 'wrtwo'
+    )
+    async def wrtwo(self, button: disnake.ui.Button, ctx: MessageInteraction):
+
+        wrone = utils.get(ctx.guild.roles, name = 'cevala feko')
+        wrtwo = utils.get(ctx.guild.roles, name = '1969 paris wind')
+        prison = utils.get(ctx.guild.roles, name = 'prisoner')
+
+        if wrtwo in ctx.author.roles:
+            return await ctx.response.send_message('You already have it lol.', ephemeral = True)
+        elif (wrone in ctx.author.roles) and (wrtwo not in ctx.author.roles):
+            await ctx.author.add_roles(prison)
+            await ctx.author.remove_roles(wrone)
+            await ctx.response.send_message('Be imprisoned.', ephemeral = True)
+            return    
+        await ctx.author.add_roles(wrtwo)
+        await ctx.response.send_message('You got it mate, congrats.', ephemeral = True)
+
+class WeeklyRoles(commands.Cog):
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def cog_load(self):
+        await self.bot.wait_until_ready() # or until connect
+        self.bot.add_view(RoleButtons())
+
+    @commands.command()
+    async def roles(self, ctx):
+        await ctx.send('Use these buttons for roles (until android devs fix slash commands smh)', view = RoleButtons())     
+
+def setup(bot):
+    bot.add_cog(WeeklyRoles(bot))

--- a/main.py
+++ b/main.py
@@ -5,7 +5,10 @@ from disnake import member
 
 import os
 
-bot = commands.Bot(command_prefix = commands.when_mentioned_or('$'), test_guilds = [848576409312165908, 848098024164294657])
+bot = commands.Bot(
+    command_prefix = commands.when_mentioned_or('$'), 
+    test_guilds = [848576409312165908, 848098024164294657]
+)
 
 for filename in os.listdir('./cogs'):
     if filename.endswith('.py'):
@@ -16,7 +19,7 @@ for filename in os.listdir('./cogs'):
 async def on_ready():
     await bot.change_presence(
         status = disnake.Status.idle, 
-        activity = disnake.Activity(type= disnake.ActivityType.watching, name = "paneer.")
+        activity = disnake.Activity(type = disnake.ActivityType.watching, name = "paneer.")
     )
     print("Bot is ready!")
     print('------')
@@ -44,24 +47,19 @@ async def unload(ctx, extension):
     await ctx.send(f'Cog {extension} is now unloaded!')
 
 @bot.command()
-@commands.has_permissions(administrator=True)
+@commands.has_permissions(administrator = True)
 async def reload(ctx, extension):
     """Use this to reload individual cogs. Usage: $reload <cog_name>"""
     bot.reload_extension(f'cogs.{extension}')
     await ctx.send(f'Cog {extension} is now reloaded!')
 
 @bot.command()
-@commands.has_permissions(administrator=True)
+@commands.has_permissions(administrator = True)
 async def reloadall(ctx):
     for filename in os.listdir('./cogs'):
         if filename.endswith('.py'):
             bot.reload_extension(f'cogs.{filename[:-3]}')
             await ctx.send(f'Cog {filename[:-3]} is now reloaded!')
-
-@bot.command()
-@commands.has_permissions(administrator=True)
-async def roles(ctx):
-    await ctx.send("Use these buttons for roles (until android devs fix slash commands smh)")
 
 token = os.environ.get('BOT_TOKEN')
 bot.run(token)

--- a/main.py
+++ b/main.py
@@ -62,6 +62,6 @@ async def reloadall(ctx):
 @commands.has_permissions(administrator=True)
 async def roles(ctx):
     await ctx.send("Use these buttons for roles (until android devs fix slash commands smh)")
-    
+
 token = os.environ.get('BOT_TOKEN')
 bot.run(token)


### PR DESCRIPTION
I realized that there is a much better way to have a cooldown for `/linkoss`, which is using the `@commands.cooldown()` coroutine.

Now, the command's use is limited to [10 times every 30 seconds] per channel. If the command is used after that limit, then the `CommandOnCooldown` error will be raised, and @LinkossLink will not be mentioned anymore. (until the cooldown ends, ofcourse)

Please find attached a very cool IRL test of this.
![image](https://user-images.githubusercontent.com/28886624/139572592-c0cc18bf-d8bb-4d44-90f2-564a82bd9a18.png)
